### PR TITLE
Feature/1 test suite

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -6,27 +6,28 @@
  * the app where the dependency chain is constructed -- every layer receives
  * its collaborator(s) via constructor (DI).
  *
- * `App` itself receives `db` from the composition root (server.ts); it does
- * not import `dbConnection.ts` directly. That keeps `App` agnostic about how
- * the database is set up (real Mongo, in-memory fake, etc.).
+ * `App` receives a `CommentRepositoryPort` from the composition root
+ * (server.ts); it does not import `CommentRepository` or `dbConnection.ts`
+ * directly. That keeps `App` agnostic about how comments are stored -- real
+ * Mongo in production, an in-memory fake in tests -- since it only ever sees
+ * the port, never the concrete adapter.
  */
 
 import cors from "cors";
 import express, { type Express } from "express";
 import type { Server } from "node:http";
-import type { Db } from "mongodb";
-import { CommentRepository } from "./comments/repository.js";
 import { CommentService } from "./comments/application.js";
+import type { CommentRepositoryPort } from "./comments/application.js";
 import { CommentController } from "./comments/presentation.js";
 import { CommentsRouter } from "./comments/routes.js";
 
 class App {
     readonly express: Express;
 
-    constructor(db: Db) {
+    constructor(repository: CommentRepositoryPort) {
         this.express = express();
         this.#configureMiddleware();
-        this.#mountRoutes(db);
+        this.#mountRoutes(repository);
     }
 
     #configureMiddleware(): void {
@@ -34,8 +35,7 @@ class App {
         this.express.use(express.json());
     }
 
-    #mountRoutes(db: Db): void {
-        const repository = new CommentRepository(db);
+    #mountRoutes(repository: CommentRepositoryPort): void {
         const service = new CommentService(repository);
         const controller = new CommentController(service);
         const commentsRouter = new CommentsRouter(controller);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,10 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.21",
         "@types/node": "^26.0.1",
+        "@types/supertest": "^7.2.0",
         "esbuild": "^0.28.1",
         "nodemon": "3.1.0",
+        "supertest": "^7.2.2",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3"
       }
@@ -475,6 +477,29 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -495,6 +520,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/cors": {
       "version": "2.8.19",
@@ -536,6 +568,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -582,6 +621,30 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/webidl-conversions": {
@@ -632,6 +695,20 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -797,6 +874,29 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -836,6 +936,13 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -856,6 +963,16 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -871,6 +988,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -936,6 +1064,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1042,6 +1186,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1069,6 +1220,41 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -1185,6 +1371,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1559,6 +1761,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1887,6 +2099,90 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -2044,6 +2340,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && esbuild build/server.js --bundle --minify --format=esm --platform=node --outfile=build/app.js",
     "start": "node build/app.js",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --import tsx --test \"test/**/*.test.ts\"",
     "db:start": "sudo systemctl start mongod",
     "db:stop": "sudo systemctl stop mongod",
     "db:status": "sudo systemctl status mongod"
@@ -34,8 +34,10 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/node": "^26.0.1",
+    "@types/supertest": "^7.2.0",
     "esbuild": "^0.28.1",
     "nodemon": "3.1.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"
   }

--- a/server.ts
+++ b/server.ts
@@ -2,15 +2,19 @@
  * Composition root.
  *
  * This is the ONLY place in the codebase that knows the full dependency graph:
- * create the DatabaseClient, connect it, hand its `db` handle to App, listen.
- * Everything downstream receives its collaborators via constructor.
+ * create the DatabaseClient, connect it, build the Mongo-backed repository from
+ * its `db` handle, hand that repository to App, listen. Everything downstream
+ * receives its collaborators via constructor -- and the one storage-specific
+ * construction (the real CommentRepository) happens here, not inside App.
  */
 
 import { App } from "./app/index.js";
+import { CommentRepository } from "./app/comments/repository.js";
 import { DatabaseClient } from "./db/dbConnection.js";
 
 const PORT = Number(process.env.PORT || 5050);
 
 const dbClient = await new DatabaseClient().connect();
-const app = new App(dbClient.db);
+const repository = new CommentRepository(dbClient.db);
+const app = new App(repository);
 app.listen(PORT);

--- a/test/domain/comment.test.ts
+++ b/test/domain/comment.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Domain unit tests (tier 2): pure, no I/O, no database.
+ *
+ * These pin down the business RULES that live on the aggregate. They are the
+ * cheapest, fastest tests in the suite -- every branch of ownership, voting
+ * and reply-targeting is exercised here so the HTTP tests don't have to.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { Comment, Reply } from "../../app/comments/domain.js";
+import { NotOwnerError } from "../../app/comments/errors.js";
+
+describe("Comment.create", () => {
+    test("starts unsaved (id null), score 0, no replies", () => {
+        const comment = Comment.create({ content: "hi", username: "amyrobson" });
+        assert.equal(comment.id, null);
+        assert.equal(comment.score, 0);
+        assert.deepEqual(comment.replies, []);
+    });
+
+    test("derives the author's avatar paths from the username", () => {
+        const comment = Comment.create({ content: "hi", username: "amyrobson" });
+        assert.equal(comment.user.username, "amyrobson");
+        assert.equal(comment.user.image.png, "/avatars/image-amyrobson.png");
+        assert.equal(comment.user.image.webp, "/avatars/image-amyrobson.webp");
+    });
+});
+
+describe("editContent", () => {
+    test("the owner may change the content", () => {
+        const comment = Comment.create({ content: "old", username: "amyrobson" });
+        comment.editContent("new", "amyrobson");
+        assert.equal(comment.content, "new");
+    });
+
+    test("a non-owner is rejected with NotOwnerError and the content is unchanged", () => {
+        const comment = Comment.create({ content: "old", username: "amyrobson" });
+        assert.throws(() => comment.editContent("hacked", "mallory"), NotOwnerError);
+        assert.equal(comment.content, "old");
+    });
+});
+
+describe("applyVote", () => {
+    test("like true adds one, like false subtracts one", () => {
+        const comment = Comment.create({ content: "hi", username: "amyrobson" });
+        comment.applyVote(true);
+        comment.applyVote(true);
+        comment.applyVote(false);
+        assert.equal(comment.score, 1);
+    });
+});
+
+describe("addReply / target / removeReply", () => {
+    test("addReply attaches a reply through the root and returns it", () => {
+        const comment = Comment.create({ content: "parent", username: "amyrobson" });
+        const reply = comment.addReply({ content: "child", replyingTo: "amyrobson", username: "maxblagun" });
+        assert.equal(comment.replies.length, 1);
+        assert.equal(reply.replyingTo, "amyrobson");
+        assert.ok(reply instanceof Reply);
+    });
+
+    test("target(id) resolves the comment itself, an embedded reply, or nothing", () => {
+        const comment = new Comment({
+            id: "a".repeat(24),
+            content: "parent",
+            createdAt: new Date(0),
+            score: 0,
+            user: { username: "amyrobson", image: { png: "", webp: "" } },
+        });
+        const reply = comment.addReply({ content: "child", replyingTo: "amyrobson", username: "maxblagun" });
+        reply.id = "b".repeat(24);
+
+        assert.equal(comment.target("a".repeat(24)), comment);
+        assert.equal(comment.target("b".repeat(24)), reply);
+        assert.equal(comment.target("c".repeat(24)), undefined);
+    });
+
+    test("removeReply drops the matching reply", () => {
+        const comment = Comment.create({ content: "parent", username: "amyrobson" });
+        const reply = comment.addReply({ content: "child", replyingTo: "amyrobson", username: "maxblagun" });
+        reply.id = "b".repeat(24);
+        comment.removeReply("b".repeat(24));
+        assert.equal(comment.replies.length, 0);
+    });
+});

--- a/test/helpers/fakeRepository.ts
+++ b/test/helpers/fakeRepository.ts
@@ -1,0 +1,56 @@
+/**
+ * In-memory CommentRepositoryPort for tests.
+ *
+ * Because the application layer depends on the PORT and not on the concrete
+ * Mongo repository, this fake is a drop-in substitute: the service can't tell
+ * the difference. It mirrors the two behaviours the real repository adds on
+ * top of storage -- assigning an id to a brand-new comment, and assigning ids
+ * to newly-added replies on save -- so use cases behave identically without a
+ * database. Ids are 24-char hex strings so they pass the controller's id check.
+ */
+
+import { Comment } from "../../app/comments/domain.js";
+import type { CommentRepositoryPort } from "../../app/comments/application.js";
+
+class FakeCommentRepository implements CommentRepositoryPort {
+    #comments = new Map<string, Comment>();
+    #seq = 0;
+
+    #nextId(): string {
+        this.#seq += 1;
+        return this.#seq.toString(16).padStart(24, "0");
+    }
+
+    async findAll(): Promise<Comment[]> {
+        return [...this.#comments.values()];
+    }
+
+    async findAggregateContaining(id: string): Promise<Comment | null> {
+        for (const comment of this.#comments.values()) {
+            if (comment.id === id || comment.replies.some(reply => reply.id === id)) {
+                return comment;
+            }
+        }
+        return null;
+    }
+
+    async add(comment: Comment): Promise<Comment> {
+        comment.id = this.#nextId();
+        this.#comments.set(comment.id, comment);
+        return comment;
+    }
+
+    async save(comment: Comment): Promise<Comment> {
+        for (const reply of comment.replies) {
+            if (reply.id === null) reply.id = this.#nextId();
+        }
+        if (comment.id) this.#comments.set(comment.id, comment);
+        return comment;
+    }
+
+    async removeComment(id: string): Promise<void> {
+        this.#comments.delete(id);
+    }
+}
+
+export { FakeCommentRepository };

--- a/test/http/comments.test.ts
+++ b/test/http/comments.test.ts
@@ -1,0 +1,134 @@
+/**
+ * HTTP integration tests (tier 1): the whole stack minus the database.
+ *
+ * The App is built with a FakeCommentRepository injected at the composition
+ * root, exactly the way server.ts injects the real one -- so one test drives
+ * request validation (presentation), use-case orchestration (application) and
+ * response mapping in a single pass, with no Mongo and no network listener
+ * (supertest talks to the Express app object directly).
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import request from "supertest";
+import { App } from "../../app/index.js";
+import { FakeCommentRepository } from "../helpers/fakeRepository.js";
+
+let api: request.SuperTest<request.Test>;
+
+beforeEach(() => {
+    api = request(new App(new FakeCommentRepository()).express);
+});
+
+async function createComment(content = "first!", username = "amyrobson") {
+    const response = await api.post("/api/comments").send({ content, username }).expect(201);
+    return response.body;
+}
+
+describe("GET /api/comments", () => {
+    test("returns 200 and an empty list when there are none", async () => {
+        const response = await api.get("/api/comments").expect(200);
+        assert.deepEqual(response.body, []);
+    });
+
+    test("returns comments that have been posted", async () => {
+        await createComment("hello");
+        const response = await api.get("/api/comments").expect(200);
+        assert.equal(response.body.length, 1);
+        assert.equal(response.body[0].content, "hello");
+    });
+});
+
+describe("POST /api/comments", () => {
+    test("creates a comment with a real id, score 0 and no replies", async () => {
+        // The Act is the POST itself, so it stays inline and explicit here --
+        // this is the one test that proves creation, so it can't lean on the
+        // createComment helper (which would be testing the endpoint via itself).
+        const response = await api
+            .post("/api/comments")
+            .send({ content: "brand new", username: "amyrobson" })
+            .expect(201);
+
+        const body = response.body;
+        assert.match(body._id, /^[0-9a-fA-F]{24}$/);
+        assert.equal(body.content, "brand new");
+        assert.equal(body.score, 0);
+        assert.deepEqual(body.replies, []);
+    });
+
+    test("posting with an id creates a reply on that aggregate", async () => {
+        const comment = await createComment();
+        const reply = await api
+            .post("/api/comments")
+            .send({ id: comment._id, content: "a reply", username: "maxblagun" })
+            .expect(201);
+        assert.equal(reply.body.replyingTo, "amyrobson");
+
+        const all = await api.get("/api/comments").expect(200);
+        assert.equal(all.body[0].replies.length, 1);
+    });
+
+    test("rejects a non-JSON content-type with 400", async () => {
+        await api
+            .post("/api/comments")
+            .set("Content-Type", "text/plain")
+            .send("content=hi")
+            .expect(400);
+    });
+
+    test("rejects an unrecognized property with 400", async () => {
+        await api
+            .post("/api/comments")
+            .send({ content: "hi", username: "amyrobson", role: "admin" })
+            .expect(400);
+    });
+});
+
+describe("PATCH /api/comments", () => {
+    test("the owner can edit content", async () => {
+        const comment = await createComment("old");
+        const response = await api
+            .patch("/api/comments")
+            .send({ id: comment._id, newContent: "edited", username: "amyrobson" })
+            .expect(200);
+        assert.equal(response.body.content, "edited");
+    });
+
+    test("a non-owner editing is rejected with 400", async () => {
+        const comment = await createComment("old");
+        await api
+            .patch("/api/comments")
+            .send({ id: comment._id, newContent: "hacked", username: "mallory" })
+            .expect(400);
+    });
+
+    test("voting changes the score", async () => {
+        const comment = await createComment();
+        const response = await api
+            .patch("/api/comments")
+            .send({ id: comment._id, like: true })
+            .expect(200);
+        assert.equal(response.body.score, 1);
+    });
+
+    test("rejects a malformed id with 400", async () => {
+        await api
+            .patch("/api/comments")
+            .send({ id: "not-a-hex-id", like: true })
+            .expect(400);
+    });
+});
+
+describe("DELETE /api/comments", () => {
+    test("the owner can delete their comment", async () => {
+        const comment = await createComment();
+        await api.delete("/api/comments").send({ id: comment._id, username: "amyrobson" }).expect(200);
+        const all = await api.get("/api/comments").expect(200);
+        assert.deepEqual(all.body, []);
+    });
+
+    test("a non-owner deleting is rejected with 400", async () => {
+        const comment = await createComment();
+        await api.delete("/api/comments").send({ id: comment._id, username: "mallory" }).expect(400);
+    });
+});


### PR DESCRIPTION
implements #1 

## Add a test suite (unit + HTTP integration)

The comments API had no automated tests. This adds two tiers of them and the
one small refactor needed to make the app testable without a database. No
runtime behaviour or HTTP contract changes.

### Enabling refactor: make `App` injectable

`App` previously received a `Db` and built `CommentRepository` internally, so
there was no seam to substitute storage in a test. It now accepts a
`CommentRepositoryPort` and depends only on that interface; the composition
root (`server.ts`) builds the Mongo-backed repository and injects it.

- Production wiring is unchanged — the real repository is still built from the
  live `db` handle, just one level up.
- `App` is now storage-agnostic: real Mongo in production, an in-memory fake in
  tests. This also tightened the dependency direction (App → port, not App → Mongo).

### Tests

**Domain unit tests** (`test/domain/comment.test.ts`) — pure, no I/O, no test
doubles (the domain has no external collaborators, so these are *solitary* unit
tests). Cover the ownership rule on `editContent`, vote arithmetic,
`addReply`/`target`/`removeReply`, and the username-derived author.

**HTTP integration tests** (`test/http/comments.test.ts`) — drive
router → controller → service → domain through the real HTTP interface with
`supertest`, with only the repository replaced by an in-memory fake. Sociable
and in-process (no real DB, no socket) — integration of the *layers*, not of the
*infrastructure*, so **not** E2E. Cover GET/POST/PATCH/DELETE happy paths plus
the validation and ownership branches.

**Test fake** (`test/helpers/fakeRepository.ts`) — `FakeCommentRepository`
implements the port with a `Map` and mirrors the two things the real repository
adds on top of storage: assigning an id on `add`, and assigning ids to new
replies on `save`.

### Tooling / packages

- Added `supertest` (+ `@types/supertest`) to drive the Express app in-process.
- Added an `npm test` script running the built-in `node:test` runner through
  `tsx` over `test/**/*.test.ts`. No new runtime dependencies.

### Verification

- `npm test` → **20 passing** (8 suites).
- `npm run typecheck` passes clean.

### Follow-ups (deliberately out of scope)

- **Repository tests against real Mongo** (tier 3) via `mongodb-memory-server`,
  to cover the `#toDomain`/`#toDocument` mapping and `findAggregateContaining` —
  the one thing the fake can't catch.
- **Typecheck gap**: test files sit outside the build `tsconfig` (so they don't
  emit into `build/`) and `tsx` only strips types, so a type error in a test
  wouldn't surface. A `tsconfig.test.json` would close this.
- The username/ownership-coupled tests are left as-is; they'll be rewritten on
  the upcoming auth branch, where swapping body-username for an authenticated
  identity turns them red → green as the correctness proof.
